### PR TITLE
Fix Issue #42

### DIFF
--- a/Droid/RefreshSample.Droid.csproj
+++ b/Droid/RefreshSample.Droid.csproj
@@ -12,7 +12,6 @@
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidApplication>True</AndroidApplication>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <AssemblyName>RefreshSample.Droid</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
@@ -39,9 +38,6 @@
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <ConsolePause>false</ConsolePause>
     <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
-    <AotAssemblies>false</AotAssemblies>
-    <EnableLLVM>false</EnableLLVM>
-    <BundleAssemblies>false</BundleAssemblies>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/PullToRefresh/PullToRefresh.Droid/PullToRefresh.Droid.csproj
+++ b/PullToRefresh/PullToRefresh.Droid/PullToRefresh.Droid.csproj
@@ -11,7 +11,6 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <AssemblyName>Refractored.XamForms.PullToRefresh.Droid</AssemblyName>
     <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
     <NuGetPackageImportStamp>

--- a/PullToRefresh/PullToRefresh.iOS/PullToRefreshLayoutRenderer.cs
+++ b/PullToRefresh/PullToRefresh.iOS/PullToRefreshLayoutRenderer.cs
@@ -24,17 +24,17 @@ using Xamarin.Forms;
 using Xamarin.Forms.Platform.iOS;
 
 
-[assembly:ExportRenderer(typeof(PullToRefreshLayout), typeof(PullToRefreshLayoutRenderer))]
+[assembly: ExportRenderer(typeof(PullToRefreshLayout), typeof(PullToRefreshLayoutRenderer))]
 namespace Refractored.XamForms.PullToRefresh.iOS
 {
 
     /// <summary>
     /// Pull to refresh layout renderer.
     /// </summary>
-    [Preserve(AllMembers=true)]
+    [Preserve(AllMembers = true)]
     public class PullToRefreshLayoutRenderer : ViewRenderer<PullToRefreshLayout, UIView>
     {
-       
+
         /// <summary>
         /// Used for registration with dependency service
         /// </summary>
@@ -44,34 +44,25 @@ namespace Refractored.XamForms.PullToRefresh.iOS
         }
 
         UIRefreshControl refreshControl;
+        UIView refreshControlParent;
 
 
         /// <summary>
         /// Raises the element changed event.
         /// </summary>
         /// <param name="e">E.</param>
-        protected override void OnElementChanged (ElementChangedEventArgs<Refractored.XamForms.PullToRefresh.PullToRefreshLayout> e)
+        protected override void OnElementChanged(ElementChangedEventArgs<Refractored.XamForms.PullToRefresh.PullToRefreshLayout> e)
         {
-            base.OnElementChanged (e);
+            base.OnElementChanged(e);
 
             if (e.OldElement != null || Element == null)
                 return;
 
-  
-
-            refreshControl = new UIRefreshControl ();
+            refreshControl = new UIRefreshControl();
 
             refreshControl.ValueChanged += OnRefresh;
 
-            try
-            {
-                TryInsertRefresh(this);
-            }
-            catch(Exception ex)
-            {
-                Debug.WriteLine("View is not supported in PullToRefreshLayout: " + ex);
-            }
-           
+            this.refreshControlParent = this;
 
             UpdateColors();
             UpdateIsRefreshing();
@@ -104,7 +95,7 @@ namespace Refractored.XamForms.PullToRefresh.iOS
 
             if (view is UICollectionView)
             {
-                
+
                 var uiCollectionView = view as UICollectionView;
                 if (!set)
                 {
@@ -114,7 +105,7 @@ namespace Refractored.XamForms.PullToRefresh.iOS
 
                 if (origininalY < 0)
                     return true;
-                
+
                 if (refreshing)
                     uiCollectionView.SetContentOffset(new CoreGraphics.CGPoint(0, origininalY - refreshControl.Frame.Size.Height), true);
                 else
@@ -122,14 +113,14 @@ namespace Refractored.XamForms.PullToRefresh.iOS
                 return true;
             }
 
-            
+
             if (view is UIWebView)
             {
                 //can't do anything
                 return true;
             }
 
-            
+
             if (view is UIScrollView)
             {
                 var uiScrollView = view as UIScrollView;
@@ -162,17 +153,18 @@ namespace Refractored.XamForms.PullToRefresh.iOS
 
             return false;
         }
-       
+
 
         bool TryInsertRefresh(UIView view, int index = 0)
         {
-
+            this.refreshControlParent = view;
 
             if (view is UITableView)
             {
                 var uiTableView = view as UITableView;
                 uiTableView = view as UITableView;
                 view.InsertSubview(refreshControl, index);
+
                 return true;
             }
 
@@ -185,7 +177,7 @@ namespace Refractored.XamForms.PullToRefresh.iOS
                 return true;
             }
 
-            
+
             if (view is UIWebView)
             {
                 var uiWebView = view as UIWebView;
@@ -256,9 +248,18 @@ namespace Refractored.XamForms.PullToRefresh.iOS
 
         void UpdateIsSwipeToRefreshEnabled()
         {
-            refreshControl.Enabled = RefreshView.IsPullToRefreshEnabled;
+            if (RefreshView.IsPullToRefreshEnabled)
+            {
+                this.TryInsertRefresh(this.refreshControlParent);
+            }
+            else
+            {
+                if (this.refreshControl.Superview != null)
+                {
+                    this.refreshControl.RemoveFromSuperview();
+                }
+            }
         }
-
 
         /// <summary>
         /// Helpers to cast our element easily
@@ -273,13 +274,14 @@ namespace Refractored.XamForms.PullToRefresh.iOS
 
 
         bool isRefreshing;
+
         /// <summary>
         /// Gets or sets a value indicating whether this instance is refreshing.
         /// </summary>
         /// <value><c>true</c> if this instance is refreshing; otherwise, <c>false</c>.</value>
         public bool IsRefreshing
         {
-            get { return isRefreshing;}
+            get { return isRefreshing; }
             set
             {
                 bool changed = IsRefreshing != value;
@@ -290,7 +292,7 @@ namespace Refractored.XamForms.PullToRefresh.iOS
                 else
                     refreshControl.EndRefreshing();
 
-                if(changed)
+                if (changed)
                     TryOffsetRefresh(this, IsRefreshing);
             }
         }
@@ -335,10 +337,12 @@ namespace Refractored.XamForms.PullToRefresh.iOS
             {
                 refreshControl.ValueChanged -= OnRefresh;
             }
+
+            this.refreshControlParent = null;
         }
-            
+
     }
 
-  
+
 }
 

--- a/RefreshSample/ViewModels/TestViewModel.cs
+++ b/RefreshSample/ViewModels/TestViewModel.cs
@@ -32,6 +32,22 @@ namespace RefreshSample.ViewModels
             Items = new ObservableCollection<string>();
         }
 
+        bool canRefresh = true;
+
+        public bool CanRefresh
+        {
+            get { return canRefresh; }
+            set
+            {
+                if (canRefresh == value)
+                    return;
+
+                canRefresh = value;
+                OnPropertyChanged("CanRefresh");
+            }
+        }
+
+
         bool isBusy;
 
         public bool IsBusy
@@ -70,7 +86,9 @@ namespace RefreshSample.ViewModels
 
                     IsBusy = false;
 
-                    page.DisplayAlert("Refreshed", "You just refreshed the page! Nice job!", "OK");
+                    page.DisplayAlert("Refreshed", "You just refreshed the page! Nice job! Pull to refresh is now disabled", "OK");
+                    this.CanRefresh = false;
+
                     return false;
                 });
         }
@@ -88,7 +106,6 @@ namespace RefreshSample.ViewModels
 
             PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
         }
-
     }
 }
 

--- a/RefreshSample/Views/ListViewPage.cs
+++ b/RefreshSample/Views/ListViewPage.cs
@@ -16,6 +16,7 @@ using System;
 using Xamarin.Forms;
 using RefreshSample.ViewModels;
 using Refractored.XamForms.PullToRefresh;
+using System.Threading.Tasks;
 
 namespace RefreshSample.Views
 {
@@ -68,7 +69,7 @@ namespace RefreshSample.Views
 
             refreshView.SetBinding(PullToRefreshLayout.IsRefreshingProperty, new Binding("IsBusy", BindingMode.OneWay));
             refreshView.SetBinding(PullToRefreshLayout.RefreshCommandProperty, new Binding("RefreshCommand"));
-
+            refreshView.SetBinding(PullToRefreshLayout.IsPullToRefreshEnabledProperty, new Binding("CanRefresh"));
 
             if (insideLayout)
             {

--- a/RefreshSample/Views/ListViewPage.cs
+++ b/RefreshSample/Views/ListViewPage.cs
@@ -25,9 +25,9 @@ namespace RefreshSample.Views
         {
             Title = "ListView (Pull to Refresh)";
 
-            BindingContext = new TestViewModel (this);
+            BindingContext = new TestViewModel(this);
 
-            var listView = new ListView ();
+            var listView = new ListView();
             //ListView now has a built in pull to refresh! 
             //You most likely could enable the listview pull to refresh and use it instead of the refresh view
             //listView.IsPullToRefreshEnabled = true;
@@ -35,20 +35,21 @@ namespace RefreshSample.Views
             //listView.SetBinding<TestViewModel>(ListView.IsRefreshingProperty, vm => vm.IsBusy, BindingMode.OneWay);
             //listView.SetBinding<TestViewModel>(ListView.RefreshCommandProperty, vm => vm.RefreshCommand);
 
-           
+
 
             listView.SetBinding(ItemsView<Cell>.ItemsSourceProperty, new Binding("Items"));
 
             //ListView now has a built in pull to refresh! 
             //You most likely could disable the listview pull to refresh and re-enable this
             //However, I wouldn't recommend that.
-            var refreshView = new PullToRefreshLayout {
+            var refreshView = new PullToRefreshLayout
+            {
                 VerticalOptions = LayoutOptions.FillAndExpand,
                 HorizontalOptions = LayoutOptions.FillAndExpand,
                 Content = new StackLayout
-                    {
-                        Spacing = 0,
-                        Children = 
+                {
+                    Spacing = 0,
+                    Children =
                             {
                                 new Label
                                 {
@@ -61,11 +62,11 @@ namespace RefreshSample.Views
                                 },
                                 listView
                             }
-                        },
+                },
                 RefreshColor = Color.FromHex("#3498db")
             };
 
-            refreshView.SetBinding(PullToRefreshLayout.IsRefreshingProperty, , new Binding("IsBusy", BindingMode.OneWay));
+            refreshView.SetBinding(PullToRefreshLayout.IsRefreshingProperty, new Binding("IsBusy", BindingMode.OneWay));
             refreshView.SetBinding(PullToRefreshLayout.RefreshCommandProperty, new Binding("RefreshCommand"));
 
 
@@ -73,8 +74,8 @@ namespace RefreshSample.Views
             {
                 Content = new StackLayout
                 {
-                        Spacing = 0,
-                        Children = 
+                    Spacing = 0,
+                    Children =
                             {
                                 new Label
                                 {


### PR DESCRIPTION
This PR has for goal to fix the issue https://github.com/jamesmontemagno/Xamarin.Forms-PullToRefreshLayout/issues/42

Having looked at this [stackoverflow post ](https://stackoverflow.com/questions/19480424/how-do-i-hide-a-uirefreshcontrol) it seems that setting .Enabled = false on a UIRefreshControl does not do anything, because it's actually the UIScrollView wrapping the UIRefreshControl that decides whether or not the control should be displayed.

Following that logic the solution seems to simply remove the UIRefreshControl from its Superview when the property IsPullToRefreshEnabled is set to false, and to try to insert it again when IsPullToRefreshEnabled is set to true.

Also updated the ListViewPage sample, to demonstrate the working databinding on the IsPullToRefreshEnabled property.

Also fixed a typo in ListViewPage.cs refreshView.SetBinding(PullToRefreshLayout.IsRefreshingProperty**, ,** new Binding("IsBusy", BindingMode.OneWay));
that was preventing the sample project from building.           


Note: Changes to the .csproj file are automatically applied by Visual Studio for mac
